### PR TITLE
[Feat]/#17 CommonButton 구현

### DIFF
--- a/kb_hab/src/components/common/CommonButton.vue
+++ b/kb_hab/src/components/common/CommonButton.vue
@@ -1,0 +1,46 @@
+<template>
+  <button :class="computedClasses" @click="handleClick">
+    <slot />
+  </button>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+// Props
+const props = defineProps({
+  variant: {
+    type: String,
+    default: 'black', // 기본값
+    validator: (v) => ['white', 'black', 'warning'].includes(v),
+  },
+  class: {
+    type: String,
+    default: '',
+  },
+  onClick: {
+    type: Function,
+    default: null,
+  },
+})
+
+// Variant 별 클래스
+const baseClass =
+  'px-4 py-2 rounded-xl flex border items-center gap-2 hover:cursor-pointer font-bold'
+
+const variants = {
+  white: 'text-black border-black bg-white hover:bg-gray-100',
+  black: 'text-white bg-black border-black hover:bg-gray-800',
+  warning: 'text-red-500 border-red-500 bg-white hover:bg-red-50',
+}
+
+const computedClasses = computed(() => {
+  return `${baseClass} ${variants[props.variant]} ${props.class}`.trim()
+})
+
+// 클릭 이벤트 처리 함수
+const handleClick = (e) => {
+  if (props.onClick) {
+    props.onClick(e)
+  }
+}
+</script>


### PR DESCRIPTION
## 🔎 작업 내용

CommonButton을 구현했습니다.

- white, black, warning(빨강)의 variant를 입력받아 구별합니다.
- class= 를 입력하면 기존 스타일을 덮어씌웁니다.
- 컴포넌트 내에 아이콘, 텍스트 등을 넣으면 버튼에 포함됩니다.
- :onClick 으로 넘긴 함수가 클릭 시 동작합니다.

## 사용 방법

```vue
<template>
  <div class="space-y-4">
    <!-- 흰 배경, 검정 테두리 (white) -->
    <CommonButton variant="white" :onClick="() => console.log('Clicked!')">
      <User class="w-4 h-4" />
      <span>Profile</span>
    </CommonButton>

    <!-- 검정 배경, 흰 글씨 (black) -->
    <CommonButton variant="black">
      <span>Confirm</span>
    </CommonButton>

    <!-- 흰 배경, 빨간 테두리 (warning) -->
    <CommonButton variant="warning" :onClick="handleDelete">
      <Trash class="w-4 h-4" />
      <span>Delete</span>
    </CommonButton>
  </div>
</template>

<script setup>
import CommonButton from '@/components/common/CommonButton.vue'
import { User, Trash } from 'lucide-vue-next'

function handleDelete() {
  alert('삭제됩니다!')
}
</script>
```
  <br/>

## 이미지 첨부

<img width="628" alt="image" src="https://github.com/user-attachments/assets/1cc9b6dc-2922-4aca-9692-86a30c202618" />


<br/>

## 🔧 논의사항

사용 시 어려움이 있으면 이야기해주세요!

  <br/>

## ➕ 이슈 링크

- #17 

<br/>
