### PR TITLE
[Feat]/#27- TransactionItem 컴포넌트 구현

### DIFF
--- a/kb_hab/src/components/TransactionItem.vue
+++ b/kb_hab/src/components/TransactionItem.vue
@@ -1,0 +1,96 @@
+<template>
+  <div
+    style="
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background-color: white;
+      padding: 16px;
+      border-radius: 12px;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+      border: 1px solid #e5e7eb;
+    "
+  >
+    <div>
+      <p style="font-size: 14px; color: #9ca3af">{{ formatDate(transaction.date) }}</p>
+      <p style="font-size: 16px; font-weight: 500">{{ transaction.title }}</p>
+    </div>
+    <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 4px">
+      <component
+        :is="getCategoryIcon(transaction.category)"
+        style="width: 20px; height: 20px; color: #6b7280"
+      />
+      <p
+        :style="{
+          color: transaction.type === '수입' ? '#22c55e' : '#000000',
+          fontSize: '16px',
+          fontWeight: '600',
+        }"
+      >
+        {{ transaction.type === '수입' ? '+' : '-' }}
+        {{ Number(transaction.amount).toLocaleString() }} 원
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+import {
+  Utensils,
+  Coffee,
+  Store,
+  Wine,
+  ShoppingCart,
+  Gamepad,
+  Stethoscope,
+  Home,
+  FileText,
+  Scissors,
+  Car,
+  GraduationCap,
+  Sprout,
+  MoreHorizontal,
+  DollarSign,
+  HandCoins,
+  PiggyBank,
+  HelpCircle,
+} from 'lucide-vue-next'
+
+const props = defineProps({
+  transaction: {
+    type: Object,
+    required: true,
+  },
+})
+
+const formatDate = (dateStr) => {
+  const [year, month, day] = dateStr.split('-')
+  return `${Number(month)}.${Number(day)}`
+}
+
+const getCategoryIcon = (category) => {
+  const map = {
+    1: Utensils,
+    2: Coffee,
+    3: Store,
+    4: Wine,
+    5: ShoppingCart,
+    6: Gamepad,
+    7: Stethoscope,
+    8: Home,
+    9: FileText,
+    10: Scissors,
+    11: Car,
+    12: GraduationCap,
+    13: Sprout,
+    14: MoreHorizontal,
+    15: DollarSign,
+    16: HandCoins,
+    17: PiggyBank,
+  }
+  return map[category] || HelpCircle
+}
+</script>
+
+<style scoped></style>

--- a/kb_hab/src/components/TransactionItem.vue
+++ b/kb_hab/src/components/TransactionItem.vue
@@ -22,7 +22,7 @@
       />
       <p
         :style="{
-          color: transaction.type === '수입' ? '#22c55e' : '#000000',
+          color: transaction.type === '수입' ? '#6AA25A' : '#000000',
           fontSize: '16px',
           fontWeight: '600',
         }"


### PR DESCRIPTION
## 🔎 작업 내용

- [ ] TransactionItem 컴포넌트 구현
- [ ] 카테고리별 ID 매핑 

  <br/>

## 이미지 첨부

`const dummyTransaction = {
  ...
  category: 1,
  type: '지출',
}`

<img width="426" alt="image" src="https://github.com/user-attachments/assets/b12eb38f-ae98-42bb-8e19-809276ef6592" />

`const dummyTransaction = {
  ...
  category: 3,
  type: '수입',
}`

<img width="428" alt="image" src="https://github.com/user-attachments/assets/b687561a-de4f-457a-a096-0ce779c056c7" />


type이 '지출'인 경우 검은색, '수입'인 경우 초록색입니다

<br/>

## 🔧 전달사항

- category는 피그마 기준 id 1부터 시작합니다.

  <br/>

## ➕ 이슈 링크
#27 

<br/>
