### PR TITLE
[Feat]/#23 home card컴포넌트/vue구현

### DIFF
--- a/kb_hab/src/components/home/HomeCard.vue
+++ b/kb_hab/src/components/home/HomeCard.vue
@@ -1,12 +1,22 @@
 <template>
-  <!-- Header  -->
-  <div class="rounded-xl shadow-md p-4 w-full flex-1 h-[98px]" :class="[bgColor, textColor]">
+  <div
+    class="rounded-xl shadow-md p-4 w-full flex-1 h-[98px] relative"
+    :class="[bgColor, textColor]"
+  >
+    <!-- 아이콘 버튼의 위치를 더 안쪽으로 이동 -->
+    <button
+      v-if="iconButton"
+      class="absolute top-3 right-3 text-gray-600 hover:text-gray-900"
+      @click="iconButton.onClick"
+    >
+      <component :is="iconButton.icon" class="w-5 h-5" />
+    </button>
+
     <div class="flex flex-col justify-between h-full">
-      <span class="text-left self-start text-sm">{{ title }}</span>
+      <span class="text-left self-start text-sm" v-html="title"></span>
       <span class="text-lg font-semibold self-end">{{ formattedAmount }} 원</span>
     </div>
   </div>
-  <!-- NavBar -->
 </template>
 
 <script setup>

--- a/kb_hab/src/components/home/HomeCard.vue
+++ b/kb_hab/src/components/home/HomeCard.vue
@@ -1,0 +1,36 @@
+<template>
+  <!-- Header  -->
+  <div class="rounded-xl shadow-md p-4 w-full flex-1 h-[98px]" :class="[bgColor, textColor]">
+    <div class="flex flex-col justify-between h-full">
+      <span class="text-left self-start text-sm">{{ title }}</span>
+      <span class="text-lg font-semibold self-end">{{ formattedAmount }} 원</span>
+    </div>
+  </div>
+  <!-- NavBar -->
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: '제목 없음',
+  },
+  amount: {
+    type: Number,
+    default: 0,
+  },
+  bgColor: {
+    type: String,
+    default: 'bg-gray-100',
+  },
+  textColor: {
+    type: String,
+    default: 'text-black',
+  },
+  iconButton: {},
+})
+
+const formattedAmount = computed(() => props.amount.toLocaleString())
+</script>

--- a/kb_hab/src/pages/HomePage.vue
+++ b/kb_hab/src/pages/HomePage.vue
@@ -1,12 +1,11 @@
 <template>
   <!-- <Header /> -->
-  <div class="p-4 space-y-6">
+  <div class="p-4 space-y-2">
     <!-- 하루 쓸 수 있는 돈 -->
-    <div>
+    <div class="h-[102px]">
       <HomeCard
-        title="이대로 가면 하루에 쓸 수 있는 돈"
-        :amount="weeklyAmount"
-        bg-color="bg-green-500"
+        title="이대로 가면 <strong>하루</strong>에 쓸 수 있는 돈"
+        bgColor="bg-[#6AA25A]"
         textColor="text-white"
       />
     </div>
@@ -16,49 +15,36 @@
       <HomeCard
         title="일주일"
         :amount="weeklyAmount"
-        bgColor="bg-gray-800"
+        bgColor="bg-[#4B4B4B]"
         textColor="text-white"
       />
       <!-- 남은 돈 -->
       <HomeCard
-        title="남은 돈 "
+        title="남은 돈"
         :amount="remainingAmount"
-        bgColor="bg-gray-100"
+        bgColor="bg-[#F8F8F8]"
         textColor="text-black"
+        :iconButton="{ icon: Pencil, onClick: handleEditBudget }"
       />
     </div>
+
+    <!-- 수입 / 지출 요약 -->
+    <!-- <NavBar /> -->
   </div>
-  <!-- <NavBar /> -->
 </template>
 
 <script setup>
 import { ref, computed } from 'vue'
+import { Pencil } from 'lucide-vue-next'
+import { useRouter } from 'vue-router'
 import HomeCard from '@/components/home/HomeCard.vue'
 
-const dailyAmount = ref(5789)
-const weeklyAmount = ref(40523)
-const remainingAmount = ref(247932)
-
-const income = ref(10000)
-const expense = ref(10000)
-const netIncome = computed(() => income.value - expense.value)
-
-const currentDate = ref(new Date())
-const formattedMonth = computed(() => {
-  const year = currentDate.value.getFullYear()
-  const month = String(currentDate.value.getMonth() + 1).padStart(2, '0')
-  return `${year}.${month}월`
-})
-
-const prevMonth = () => {
-  const date = new Date(currentDate.value)
-  date.setMonth(date.getMonth() - 1)
-  currentDate.value = date
+const router = useRouter()
+const handleEditBudget = () => {
+  router.push('/setting/budget')
 }
 
-const nextMonth = () => {
-  const date = new Date(currentDate.value)
-  date.setMonth(date.getMonth() + 1)
-  currentDate.value = date
-}
+const dailyAmount = ref()
+const weeklyAmount = ref()
+const remainingAmount = ref()
 </script>

--- a/kb_hab/src/pages/HomePage.vue
+++ b/kb_hab/src/pages/HomePage.vue
@@ -1,3 +1,64 @@
 <template>
-  <h2>HomePage</h2>
+  <!-- <Header /> -->
+  <div class="p-4 space-y-6">
+    <!-- 하루 쓸 수 있는 돈 -->
+    <div>
+      <HomeCard
+        title="이대로 가면 하루에 쓸 수 있는 돈"
+        :amount="weeklyAmount"
+        bg-color="bg-green-500"
+        textColor="text-white"
+      />
+    </div>
+
+    <div class="flex gap-3">
+      <!-- 일주일 -->
+      <HomeCard
+        title="일주일"
+        :amount="weeklyAmount"
+        bgColor="bg-gray-800"
+        textColor="text-white"
+      />
+      <!-- 남은 돈 -->
+      <HomeCard
+        title="남은 돈 "
+        :amount="remainingAmount"
+        bgColor="bg-gray-100"
+        textColor="text-black"
+      />
+    </div>
+  </div>
+  <!-- <NavBar /> -->
 </template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import HomeCard from '@/components/home/HomeCard.vue'
+
+const dailyAmount = ref(5789)
+const weeklyAmount = ref(40523)
+const remainingAmount = ref(247932)
+
+const income = ref(10000)
+const expense = ref(10000)
+const netIncome = computed(() => income.value - expense.value)
+
+const currentDate = ref(new Date())
+const formattedMonth = computed(() => {
+  const year = currentDate.value.getFullYear()
+  const month = String(currentDate.value.getMonth() + 1).padStart(2, '0')
+  return `${year}.${month}월`
+})
+
+const prevMonth = () => {
+  const date = new Date(currentDate.value)
+  date.setMonth(date.getMonth() - 1)
+  currentDate.value = date
+}
+
+const nextMonth = () => {
+  const date = new Date(currentDate.value)
+  date.setMonth(date.getMonth() + 1)
+  currentDate.value = date
+}
+</script>

--- a/kb_hab/src/pages/HomeView.vue
+++ b/kb_hab/src/pages/HomeView.vue
@@ -1,5 +1,0 @@
-<template>
-  <h2>
-  HomeView
-</h2>
-</template>


### PR DESCRIPTION
## 🔎 #23 home card컴포넌트/vue구현

- [#23] HomeCard 컴포넌트 구현 후, 이대로가면 하루에 쓸 수 있는돈, 일주일, 남은 돈 구현
- [#23] 남은돈에서 Pencil 아이콘 클릭시 /setting/budget으로 이동

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/91ca22cc-620b-4232-9211-615c717a8ec7)


<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 논의사항

- 해당 컴포넌트 높이 괜찮나요 ,,, 이대로가면 하루에 쓸 수 있는 돈 높이만 좀 더 높일까욥

  <br/>

## ➕ 이슈 링크

- #23 

<br/>
