### PR TITLE
[Feat] GoBackHeaderLayout 구현

### DIFF
--- a/kb_hab/src/components/layout/GoBackHeaderLayout.vue
+++ b/kb_hab/src/components/layout/GoBackHeaderLayout.vue
@@ -1,0 +1,28 @@
+<script setup>
+import { ChevronLeft } from 'lucide-vue-next'
+import IconButton from '../common/IconButton.vue'
+import { useRouter } from 'vue-router'
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+})
+
+const router = useRouter()
+
+const handleClick = () => {
+  router.back()
+}
+</script>
+
+<template>
+  <div class="flex w-full h-[48px] items-center bg-white">
+    <IconButton :onClick="handleClick">
+      <ChevronLeft />
+    </IconButton>
+    <span class="text-lg font-semibold ml-2">{{ props.title }}</span>
+  </div>
+</template>

--- a/kb_hab/src/components/layout/GoBackHeaderLayout.vue
+++ b/kb_hab/src/components/layout/GoBackHeaderLayout.vue
@@ -7,7 +7,7 @@ import { defineProps } from 'vue'
 const props = defineProps({
   title: {
     type: String,
-    required: true,
+    required: false,
   },
 })
 


### PR DESCRIPTION
## 🔎 작업 내용

GoBackHeaderLayout 구현
- title에 넣은 값이 제목으로 들어갑니다

### 사용 예시

```vue
<GoBackHeaderLayout title="월 예산 설정" />
```
  <br/>

## 이미지 첨부

<img width="392" alt="image" src="https://github.com/user-attachments/assets/ac08cb55-5d4c-4826-b7bb-51ea09884ba3" />

<br/>

## 🔧 논의사항

- 이야기 할 부분이 있다면 작성해주세요.

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
