### PR TITLE
[Feat] budgetStore 구현 + 테스트 작성

### DIFF
--- a/kb_hab/package-lock.json
+++ b/kb_hab/package-lock.json
@@ -26,6 +26,7 @@
         "@tailwindcss/vite": "^4.1.3",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vue/eslint-config-prettier": "^10.2.0",
+        "axios-mock-adapter": "^2.1.0",
         "eslint": "^9.22.0",
         "eslint-plugin-vue": "~10.0.0",
         "globals": "^16.0.0",
@@ -34,7 +35,8 @@
         "unplugin-auto-import": "^19.1.2",
         "unplugin-vue-components": "^28.4.1",
         "vite": "^6.2.4",
-        "vite-plugin-vue-devtools": "^7.7.2"
+        "vite-plugin-vue-devtools": "^7.7.2",
+        "vitest": "^3.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1989,6 +1991,121 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+      "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+      "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+      "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+      "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+      "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.1",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/babel-helper-vue-transform-on": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.4.0.tgz",
@@ -2405,6 +2522,15 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-validator": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
@@ -2426,6 +2552,19 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2537,6 +2676,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2581,6 +2729,22 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2596,6 +2760,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2760,6 +2933,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2929,6 +3111,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3279,6 +3467,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -3707,6 +3904,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-docker": {
@@ -4263,6 +4483,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4607,6 +4833,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -4933,6 +5168,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4978,6 +5219,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true
     },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
@@ -5082,6 +5335,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
@@ -5097,6 +5362,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5454,6 +5746,28 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+      "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-inspect": {
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-0.8.9.tgz",
@@ -5527,6 +5841,75 @@
       },
       "peerDependencies": {
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+      "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "3.1.1",
+        "@vitest/mocker": "3.1.1",
+        "@vitest/pretty-format": "^3.1.1",
+        "@vitest/runner": "3.1.1",
+        "@vitest/snapshot": "3.1.1",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.2.0",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.8.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.1.1",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.1.1",
+        "@vitest/ui": "3.1.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue": {
@@ -5618,6 +6001,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/kb_hab/package.json
+++ b/kb_hab/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "test": "vitest"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
@@ -29,6 +30,7 @@
     "@tailwindcss/vite": "^4.1.3",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^10.2.0",
+    "axios-mock-adapter": "^2.1.0",
     "eslint": "^9.22.0",
     "eslint-plugin-vue": "~10.0.0",
     "globals": "^16.0.0",
@@ -37,6 +39,7 @@
     "unplugin-auto-import": "^19.1.2",
     "unplugin-vue-components": "^28.4.1",
     "vite": "^6.2.4",
-    "vite-plugin-vue-devtools": "^7.7.2"
+    "vite-plugin-vue-devtools": "^7.7.2",
+    "vitest": "^3.1.1"
   }
 }

--- a/kb_hab/src/stores/budgetStore.js
+++ b/kb_hab/src/stores/budgetStore.js
@@ -1,0 +1,77 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import axios from 'axios'
+
+export const useBudgetStore = defineStore('budgetStore', () => {
+  const BASE_URL = 'http://localhost:3000'
+  const remainingBudget = ref(0)
+  const dailyRemainingBudget = ref(0)
+  const weeklyRemainingBudget = ref(0)
+  const monthlyExpenditure = ref(0)
+  const monthlyBudget = ref(0)
+
+  const fetchMonthlyBudget = async () => {
+    try {
+      const response = await axios.get(BASE_URL + '/user')
+      monthlyBudget.value = response.data[0].budgetMonthly
+    } catch (err) {
+      console.error('fetchMonthlyBudget', err)
+      throw err
+    }
+  }
+
+  const getDaysInCurrentMonth = () => {
+    const now = new Date()
+    const year = now.getFullYear()
+    const month = now.getMonth() // 0-based (0 = January)
+    // 다음 달 0일 = 이번 달 마지막 날
+    return new Date(year, month + 1, 0).getDate()
+  }
+
+  const fetchMonthlyExpenditure = async () => {
+    const now = new Date()
+    const currentMonth = now.getMonth() + 1
+    const currentYear = now.getFullYear()
+    const monthStr = String(currentMonth).padStart(2, '0') // 월을 항상 두 자리로 맞춤 (예: 4 -> "04")
+    const startDate = Number(`${currentYear}${monthStr}01`) // 시작일과 종료일 YYYYMMDD 형태로 계산
+    const lastDay = new Date(currentYear, currentMonth, 0).getDate()
+    const endDate = Number(`${currentYear}${monthStr}${String(lastDay).padStart(2, '0')}`)
+
+    try {
+      // 서버에서 해당 월의 INCOME만 가져오기
+      const response = await axios.get(BASE_URL + '/transactions', {
+        params: {
+          type: 'EXPENDITURE',
+          date_gte: startDate,
+          date_lte: endDate,
+        },
+      })
+
+      // 총합 계산
+      monthlyExpenditure.value = response.data.reduce((sum, tx) => sum + tx.amount, 0)
+    } catch (err) {
+      console.error('fetchMonthlyExpenditure', err)
+      throw err
+    }
+  }
+
+  const initBudget = async () => {
+    await fetchMonthlyBudget()
+    await fetchMonthlyExpenditure()
+
+    remainingBudget.value = monthlyBudget.value - monthlyExpenditure.value
+
+    const days = getDaysInCurrentMonth()
+    dailyRemainingBudget.value =
+      days > 0 ? Math.floor(remainingBudget.value / days) : 0
+    weeklyRemainingBudget.value = dailyRemainingBudget.value * 7
+  }
+
+  return {
+    monthlyBudget,
+    remainingBudget,
+    dailyRemainingBudget,
+    weeklyRemainingBudget,
+    initBudget,
+  }
+})

--- a/kb_hab/src/stores/budgetStore.js
+++ b/kb_hab/src/stores/budgetStore.js
@@ -1,15 +1,18 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import axios from 'axios'
 
 export const useBudgetStore = defineStore('budgetStore', () => {
   const BASE_URL = 'http://localhost:3000'
+
+  // state
   const remainingBudget = ref(0)
   const dailyRemainingBudget = ref(0)
   const weeklyRemainingBudget = ref(0)
   const monthlyExpenditure = ref(0)
   const monthlyBudget = ref(0)
 
+  // actions
   const fetchMonthlyBudget = async () => {
     try {
       const response = await axios.get(BASE_URL + '/user')
@@ -47,6 +50,8 @@ export const useBudgetStore = defineStore('budgetStore', () => {
         },
       })
 
+      // 2024-04-01 -> 20240401 timestamp :179800000
+
       // 총합 계산
       monthlyExpenditure.value = response.data.reduce((sum, tx) => sum + tx.amount, 0)
     } catch (err) {
@@ -62,16 +67,39 @@ export const useBudgetStore = defineStore('budgetStore', () => {
     remainingBudget.value = monthlyBudget.value - monthlyExpenditure.value
 
     const days = getDaysInCurrentMonth()
-    dailyRemainingBudget.value =
-      days > 0 ? Math.floor(remainingBudget.value / days) : 0
+    dailyRemainingBudget.value = days > 0 ? Math.floor(remainingBudget.value / days) : 0
     weeklyRemainingBudget.value = dailyRemainingBudget.value * 7
   }
 
+  //getters
+  function getMonthlyBudget() {
+    return computed(() => {
+      return monthlyBudget.value
+    })
+  }
+
+  function getRemainingBudget() {
+    return computed(() => {
+      return remainingBudget.value
+    })
+  }
+
+  function getDailyRemainingBudget() {
+    return computed(() => {
+      return dailyRemainingBudget.value
+    })
+  }
+
+  function getWeeklyRemainingBudget() {
+    return computed(() => {
+      return weeklyRemainingBudget.value
+    })
+  }
   return {
-    monthlyBudget,
-    remainingBudget,
-    dailyRemainingBudget,
-    weeklyRemainingBudget,
+    getMonthlyBudget,
+    getRemainingBudget,
+    getDailyRemainingBudget,
+    getWeeklyRemainingBudget,
     initBudget,
   }
 })

--- a/kb_hab/src/test/basic.test.js
+++ b/kb_hab/src/test/basic.test.js
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest'
+
+// 참조 : https://ko.vuejs.org/guide/scaling-up/testing
+
+// vitest 동작 확인 테스트
+test('1 + 2 = 3', () => {
+    expect(1+2).toBe(3)
+  })

--- a/kb_hab/src/test/budgetStore.test.js
+++ b/kb_hab/src/test/budgetStore.test.js
@@ -11,21 +11,18 @@ describe('budgetStore', () => {
     setActivePinia(createPinia())
 
     // mock user 예산
-    mock.onGet('http://localhost:3000/user').reply(200, [
-      { budgetMonthly: 300000 },
-    ])
+    mock.onGet('http://localhost:3000/user').reply(200, [{ budgetMonthly: 300000 }])
 
     // mock 이번 달 expenditure
-    mock.onGet('http://localhost:3000/transactions', {
-      params: {
-        type: 'EXPENDITURE',
-        date_gte: 20250401,
-        date_lte: 20250430,
-      },
-    }).reply(200, [
-      { amount: 8000 },
-      { amount: 12000 },
-    ])
+    mock
+      .onGet('http://localhost:3000/transactions', {
+        params: {
+          type: 'EXPENDITURE',
+          date_gte: 20250401,
+          date_lte: 20250430,
+        },
+      })
+      .reply(200, [{ amount: 8000 }, { amount: 12000 }])
   })
 
   test('budgetStore 초기화, 남은 예산 확인', async () => {
@@ -38,10 +35,10 @@ describe('budgetStore', () => {
     await store.initBudget()
 
     // then
-    expect(store.monthlyBudget).toBe(300000)
-    expect(store.remainingBudget).toBe(280000)
+    expect(store.getMonthlyBudget().value).toBe(300000)
+    expect(store.getRemainingBudget().value).toBe(280000)
 
-    expect(store.dailyRemainingBudget).toBe(Math.floor(280000 / 30))
-    expect(store.weeklyRemainingBudget).toBe(store.dailyRemainingBudget * 7)
+    expect(store.getDailyRemainingBudget().value).toBe(Math.floor(280000 / 30))
+    expect(store.getWeeklyRemainingBudget().value).toBe(store.getDailyRemainingBudget().value * 7)
   })
 })

--- a/kb_hab/src/test/budgetStore.test.js
+++ b/kb_hab/src/test/budgetStore.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, beforeEach, test } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useBudgetStore } from '@/stores/budgetStore'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+
+const mock = new MockAdapter(axios)
+
+describe('budgetStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+
+    // mock user 예산
+    mock.onGet('http://localhost:3000/user').reply(200, [
+      { budgetMonthly: 300000 },
+    ])
+
+    // mock 이번 달 expenditure
+    mock.onGet('http://localhost:3000/transactions', {
+      params: {
+        type: 'EXPENDITURE',
+        date_gte: 20250401,
+        date_lte: 20250430,
+      },
+    }).reply(200, [
+      { amount: 8000 },
+      { amount: 12000 },
+    ])
+  })
+
+  test('budgetStore 초기화, 남은 예산 확인', async () => {
+    // given
+    // 25년 4월 예산: 300,000원
+    // 25년 4월 지출: 도합 20,000원 -> 남은 예산: 280,000원
+    const store = useBudgetStore()
+
+    // when
+    await store.initBudget()
+
+    // then
+    expect(store.monthlyBudget).toBe(300000)
+    expect(store.remainingBudget).toBe(280000)
+
+    expect(store.dailyRemainingBudget).toBe(Math.floor(280000 / 30))
+    expect(store.weeklyRemainingBudget).toBe(store.dailyRemainingBudget * 7)
+  })
+})

--- a/kb_hab/src/test/json-server.test.js
+++ b/kb_hab/src/test/json-server.test.js
@@ -1,0 +1,26 @@
+import axios from "axios";
+import { test, expect } from "vitest";
+
+const API_BASE = 'http://localhost:3000'
+
+test('유저 목록을 받는다', async () => {
+    const response = await axios.get(`${API_BASE}/user`)
+    expect(response.status).toBe(200)
+    expect(response.data[0]).toHaveProperty('nickname', '홍길동')
+})
+
+test('카테고리를 모두 가져온다', async () => {
+    const response = await axios.get(`${API_BASE}/category`)
+    expect(response.status).toBe(200)
+    expect(response.data.length).toBe(3)
+  })
+
+test('거래 내역 중 하나의 상세 정보를 확인한다', async () => {
+const response = await axios.get(`${API_BASE}/transactions/1`)
+expect(response.status).toBe(200)
+expect(response.data).toMatchObject({
+    title: '점심 식사',
+    amount: 8000,
+    type: 'EXPENDITURE'
+})
+})


### PR DESCRIPTION
## 🔎 작업 내용

HomeView에서 상단에 위치한 남은 예산, 일일 예산, 주간 예산에 필요한 데이터 조회 및 처리를 담당하는 budgetStore를 구현하고 테스트 코드를 작성하였습니다.
- budgetStore.js 를 Pinia를 이용해 구현하였습니다.
- 데이터 사용을 위해 필요한 컴포넌트 마운트 시 초기화 함수를 호출해야 합니다. (onMounted 등)
- 데이터를 초기화하는 initBudget 함수와 아래 필드를 store.ㅇㅇㅇ으로 접근할 수 있습니다.
  - monthlyBudget
  - remainingBudget
  - dailyRemainingBudget
  - weeklyRemainingBudget
- 테스트 코드 작성을 위해 라이브러리를 추가하였습니다:
  - vitest: 3.1.1
  - axios-mock-adapter: 2.1.0
  - 테스트 코드에만 적용되므로 기존 코드에 영향을 주지 않습니다.

### 사용 예시

```vue
<script setup>
import { onMounted } from 'vue'
import { useBudgetStore } from '@/stores/budgetStore'

const budgetStore = useBudgetStore()

onMounted(async () => {
  await budgetStore.initBudget()
})
</script>

<template>
  <div>
    💸 이번달 남은 예산: {{ budgetStore.getRemainingBudget().value }}
    <br />
    📅 하루에 쓸 수 있는 돈: {{ budgetStore.getDailyRemainingBudget().value }}
    <br />
    📆 일주일 예산: {{ budgetStore.getWeeklyRemainingBudget().value }}
  </div>
</template>
```

  <br/>

## 이미지 첨부

테스트 코드 일부와 성공 스크린샷을 첨부합니다.

```js
test('budgetStore 초기화, 남은 예산 확인', async () => {
    // given
    // 25년 4월 예산: 300,000원
    // 25년 4월 지출: 도합 20,000원 -> 남은 예산: 280,000원
    const store = useBudgetStore()

    // when
    await store.initBudget()

    // then
    expect(store.getMonthlyBudget().value).toBe(300000)
    expect(store.getRemainingBudget().value).toBe(280000)

    expect(store.getDailyRemainingBudget().value).toBe(Math.floor(280000 / 30))
    expect(store.getWeeklyRemainingBudget().value).toBe(store.getDailyRemainingBudget().value * 7)
  })
```

<img width="469" alt="image" src="https://github.com/user-attachments/assets/72ea129f-bcba-44a4-a206-8e29fdcb7ee1" />

<br/>

## 🔧 논의사항

- transaction 내 `date` 필드의 json-server 호출 시 쿼리 파라미터를 통한 필터링 이용을 위해 테스트 데이터의 date 형식을 '2024-04-10' 에서 '20240410'으로 바꾸어 진행하였습니다. 따라서 현재 DB에서는 제대로 동작하지 않습니다. 데이터 필드 수정을 논의하고 싶습니다.

  <br/>

## ➕ 이슈 링크

- #78 

<br/>
