### PR TITLE
[Fix] budgetStore에서 일일 및 주간 예산 구하는 로직 변경 + UI 수정

### DIFF
--- a/kb_hab/src/components/home/HomeCard.vue
+++ b/kb_hab/src/components/home/HomeCard.vue
@@ -1,22 +1,20 @@
 <template>
   <div
-    class="rounded-xl shadow-md p-4 w-full flex-1 min-h-[98px] relative"
+    class="flex flex-col justify-between rounded-xl shadow-md p-4 w-full flex-1 min-h-[98px] relative"
     :class="[bgColor, textColor]"
   >
-    <!-- 아이콘 버튼의 위치를 더 안쪽으로 이동 -->
-
-    <div class="flex flex-col justify-between h-full">
-      <div class="flex w-full justify-between items-start">
-        <span class="text-left self-start text-sm" v-html="title"></span>
-        <IconButton
-          v-if="iconButton"
-          :onClick="iconButton.onClick"
-          class="text-gray-600 hover:text-gray-900"
-        >
-          <component :is="iconButton.icon" class="w-5 h-5" />
-        </IconButton>
-      </div>
-      <slot />
+    <div class="flex justify-between items-start w-full h-full">
+      <span class="text-left self-start text-sm" v-html="title"></span>
+      <IconButton
+        v-if="iconButton"
+        :onClick="iconButton.onClick"
+        class="text-gray-600 hover:text-gray-900"
+      >
+        <component :is="iconButton.icon" class="w-5 h-5" />
+      </IconButton>
+    </div>
+    <slot />
+    <div class="w-full flex justify-end">
       <span class="text-lg font-semibold self-end">{{ formattedAmount }} 원</span>
     </div>
   </div>

--- a/kb_hab/src/stores/budgetStore.js
+++ b/kb_hab/src/stores/budgetStore.js
@@ -23,12 +23,14 @@ export const useBudgetStore = defineStore('budgetStore', () => {
     }
   }
 
-  const getDaysInCurrentMonth = () => {
+  const getRemainingDaysInCurrentMonth = () => {
     const now = new Date()
     const year = now.getFullYear()
-    const month = now.getMonth() // 0-based (0 = January)
-    // 다음 달 0일 = 이번 달 마지막 날
-    return new Date(year, month + 1, 0).getDate()
+    const month = now.getMonth()
+    const today = now.getDate()
+
+    const lastDayOfMonth = new Date(year, month + 1, 0).getDate()
+    return lastDayOfMonth - today
   }
 
   const fetchMonthlyExpenditure = async () => {
@@ -66,8 +68,9 @@ export const useBudgetStore = defineStore('budgetStore', () => {
 
     remainingBudget.value = monthlyBudget.value - monthlyExpenditure.value
 
-    const days = getDaysInCurrentMonth()
-    dailyRemainingBudget.value = days > 0 ? Math.floor(remainingBudget.value / days) : 0
+    const remainingDays = getRemainingDaysInCurrentMonth()
+    dailyRemainingBudget.value =
+      remainingDays > 0 ? Math.floor(remainingBudget.value / remainingDays) : 0
     weeklyRemainingBudget.value = dailyRemainingBudget.value * 7
   }
 


### PR DESCRIPTION
## 🔎 작업 내용

- 기존 남은 예산에서 항상 한 달 전체 일(days) 수를 나누던 로직을 오늘부터 남은 일(days) 수로 나누도록 수정
- HomeCard UI 버그 수정

  <br/>

## 이미지 첨부

<img width="960" alt="image" src="https://github.com/user-attachments/assets/30c17c16-3310-47ff-8fd1-3499cd18de9f" />

<br/>

## 🔧 논의사항

- 이야기 할 부분이 있다면 작성해주세요.

  <br/>

## ➕ 이슈 링크

- #115 

<br/>
